### PR TITLE
デザイン調整2

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -80,6 +80,17 @@ h1 {
   width: fit-content;
 }
 
+.dropdown-menu {
+  --bs-dropdown-border-color: #DFCDBA;
+  --bs-dropdown-min-width: 12rem
+}
+
+.dropdown-menu li:hover {
+  background-color: #F5EFE8;
+  border-color: #F5EFE8;
+  border-radius: 8px;
+}
+
 @media screen and (max-width: 834px) {
   .header {
     padding: 0 10px ;

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -153,6 +153,11 @@ h1 {
   margin-inline: auto;
 }
 
+.firstview__login {
+  display: flex;
+  justify-content: center;
+}
+
 /* ログイン・新規登録・プロフィール編集・ユーザー情報変更 */
 #login__box,
 #registration__box,

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -109,13 +109,6 @@ h1 {
     position: relative;
     z-index: 9999;
   }
-
-  .header__registration-button, .header__login-button {
-    --bs-btn-padding-y: 0.25rem;
-    --bs-btn-padding-x: 0.5rem;
-    --bs-btn-font-size: 0.875rem;
-    --bs-btn-border-radius: var(--bs-border-radius-sm);
-  }
 }
 
 /* deviseエラーメッセージ・エラーメッセージ */

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -15,10 +15,14 @@
  */
 @import "bootstrap";
 @import url("https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css");
+@import url('https://fonts.googleapis.com/css2?family=Murecho:wght@100..900&display=swap');
 
 body {
   color: #333333;
-  font-family: sans-serif;
+  font-family: "Murecho", sans-serif;
+  font-optical-sizing: auto;
+  font-weight: 400;
+  font-style: normal;
 }
 
 a {

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -136,7 +136,17 @@ h1 {
 
  /* ファーストビュー */
 .firstview-title {
-  text-align: center;
+  font-size: 28px;
+}
+
+.firstview__introduction {
+  width: fit-content;
+  margin-inline: auto;
+}
+
+.firstview__introduction .bi::before {
+  font-size: 1.5em;
+  color: #D39388;
 }
 
 /* ログイン・新規登録・プロフィール編集・ユーザー情報変更 */

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -139,12 +139,7 @@ h1 {
   font-size: 28px;
 }
 
-.firstview__introduction {
-  width: fit-content;
-  margin-inline: auto;
-}
-
-.firstview__introduction .bi::before {
+.firstview__introduction-container .bi::before {
   font-size: 1.5em;
   color: #D39388;
 }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -104,11 +104,6 @@ h1 {
   .page__container {
     padding-top: 70px;
   }
-
-  .header__dropdown__menu {
-    position: relative;
-    z-index: 9999;
-  }
 }
 
 /* deviseエラーメッセージ・エラーメッセージ */

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -91,6 +91,18 @@ h1 {
   border-radius: 8px;
 }
 
+.header__dropdown--pc .btn:hover {
+  background-color: #F5EFE8;
+  border-color: #F5EFE8;
+  border-radius: 8px;
+}
+
+@media screen and (min-width: 835px) {
+  .header__dropdown--mobile {
+    display: none;
+  }
+}
+
 @media screen and (max-width: 834px) {
   .header {
     padding: 0 10px ;
@@ -99,6 +111,10 @@ h1 {
     width: 100%;
     z-index: 9999;
     position: fixed;
+  }
+
+  .header__dropdown--pc {
+    display: none;
   }
 
   .page__container {

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -144,6 +144,15 @@ h1 {
   color: #D39388;
 }
 
+.firstview__video-title {
+  font-size: 18px;
+}
+
+.firstview__introduction-table {
+  width: fit-content;
+  margin-inline: auto;
+}
+
 /* ログイン・新規登録・プロフィール編集・ユーザー情報変更 */
 #login__box,
 #registration__box,

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -302,26 +302,12 @@ h1 {
 
 /* ブックマーク詳細 */
 #bookmark-video {
-  position: relative;
-  aspect-ratio: 16 / 9;
-  width: 100%;
   max-width: 856px;
   max-height: 482px;
-  margin-inline: auto;
-}
-
-#bookmark-video iframe {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
 }
 
 @media screen and (max-width: 834px) {
   #bookmark-video {
-    aspect-ratio: 16 / 9;
-    width: 100%;
     max-width: 560px;
     max-height: 315px;
   }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,5 @@
 class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
-  include BookmarksHelper
 
   private
 

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -34,14 +34,7 @@ class CategoriesController < ApplicationController
       flash[:notice] = "カテゴリー名を編集しました"
       redirect_to category_path(@category)
     else
-      @category = Category.find(params[:id])
-      # カテゴリー名がバリデーションエラーになった場合（blankの場合）、renderされたshowページで
-      # カテゴリー名が表示されないため編集前のデータを設定
-      @categories = @user.categories
-      # renderされたshowページでカテゴリー一覧が表示できるようインスタンス変数を設定
-      flash[:edit_error_message] = "カテゴリー名を入力してください"
-      # @categoryを設定したことでエラーメッセージが表示されなくなるためフラッシュメッセージでエラーを通知
-      render 'categories/show', status: :unprocessable_entity
+      render 'edit', status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,0 +1,5 @@
+class Users::RegistrationsController < Devise::RegistrationsController
+  def after_update_path_for(resource)
+    user_path(@user)
+  end
+end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -4,7 +4,7 @@ class Users::SessionsController < Devise::SessionsController
   def guest_sign_in
     user = User.guest
     sign_in user
-    redirect_to root_path
+    redirect_to bookmarks_path
     flash[:notice] = "ゲストユーザーとしてログインしました"
   end
 
@@ -19,5 +19,9 @@ class Users::SessionsController < Devise::SessionsController
       flash[:notice] = "ユーザーが見つかりません"
       redirect_to new_user_registration_path
     end
+  end
+
+  def after_sign_in_path_for(resource)
+    bookmarks_path
   end
 end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -4,3 +4,4 @@
 import "@hotwired/turbo-rails"
 import "controllers"
 import "bookmarks/timestamps"
+import "home/timestamps"

--- a/app/javascript/home/timestamps.js
+++ b/app/javascript/home/timestamps.js
@@ -1,0 +1,35 @@
+function jumpToIntroduction0() {
+  let timestamp = document.getElementById('firstview-button0');
+  if(timestamp) {
+    timestamp.addEventListener('click', function() {
+    let video = document.getElementById('firstview-video');
+    video.innerHTML = '<iframe width="560" height="315" src="https://www.youtube.com/embed/Tkr-itfalqw?start=8" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>'
+    });
+  }
+}
+
+function jumpToIntroduction1() {
+  let timestamp = document.getElementById('firstview-button1');
+  if(timestamp) {
+    timestamp.addEventListener('click', function() {
+    let video = document.getElementById('firstview-video');
+    video.innerHTML = '<iframe width="560" height="315" src="https://www.youtube.com/embed/Tkr-itfalqw?start=32" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>'
+    });
+  }
+}
+
+function jumpToIntroduction2() {
+  let timestamp = document.getElementById('firstview-button2');
+  if(timestamp) {
+    timestamp.addEventListener('click', function() {
+    let video = document.getElementById('firstview-video');
+    video.innerHTML = '<iframe width="560" height="315" src="https://www.youtube.com/embed/Tkr-itfalqw?start=55" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>'
+    });
+  }
+}
+
+document.addEventListener('turbo:load', function() {
+    jumpToIntroduction0();
+    jumpToIntroduction1();
+    jumpToIntroduction2();
+  });

--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -9,7 +9,7 @@ class Bookmark < ApplicationRecord
   YOUTUBE_URL_PATTERN = /\A((?:https:\/\/www\.youtube\.com(?:\/embed\/|\/watch\?v=)|https:\/\/youtu\.be\/|https:\/\/m\.youtube\.com\/watch\?v=)([\w-]{11})).*\z/
   validates :url,
     presence: true,
-    format: { with: YOUTUBE_URL_PATTERN }
+    format: { with: YOUTUBE_URL_PATTERN, allow_blank: true }
   validates :video_id, length: { is: 11, allow_blank: true }
   validates :description, length: { maximum: 300 }
 

--- a/app/views/bookmarks/edit.html.erb
+++ b/app/views/bookmarks/edit.html.erb
@@ -4,8 +4,8 @@
   <div id="bookmark-edit__row" class="row justify-content-center align-items-center">
     <div id="bookmark-edit__column" class="col-lg-8 col-md-10">
       <div class="bookmark-edit__video-container">
-        <div id="bookmark-video">
-          <iframe width="560" height="315" src="https://www.youtube.com/embed/<%= @bookmark.video_id %>" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+        <div id="bookmark-video" class="ratio ratio-16x9">
+          <iframe src="https://www.youtube.com/embed/<%= @bookmark.video_id %>" title="YouTube video player" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
         </div>
       </div>
 

--- a/app/views/bookmarks/edit.html.erb
+++ b/app/views/bookmarks/edit.html.erb
@@ -31,7 +31,7 @@
                   <%= f.label :category, "カテゴリー", class: "d-block mb-1" %>
                   <%= f.collection_check_boxes(:category_ids, @user.categories, :id, :name) do |category| %>
                     <%= category.check_box class: "btn-check" %>
-                    <%= category.label class: "bookmark-edit__category-button btn" do %>
+                    <%= category.label class: "bookmark-edit__category-button btn shadow-sm" do %>
                       <%= category.text %>
                     <% end %>
                   <% end %>
@@ -54,7 +54,7 @@
             </div>
 
             <div class="bookmark-edit__form-group-action">
-              <%= f.submit "登録", class: "bookmark-edit__button btn mb-5" %>
+              <%= f.submit "登録", class: "bookmark-edit__button btn shadow-sm mb-5" %>
             </div>
           <% end %>
         </div>

--- a/app/views/bookmarks/edit.html.erb
+++ b/app/views/bookmarks/edit.html.erb
@@ -56,11 +56,6 @@
             <div class="bookmark-edit__form-group-action">
               <%= f.submit "登録", class: "bookmark-edit__button btn mb-5" %>
             </div>
-
-            <div class="bookmark__back">
-              <%= link_to "戻る", "javascript:history.back()" %>
-            </div>
-
           <% end %>
         </div>
       </div>

--- a/app/views/bookmarks/index.html.erb
+++ b/app/views/bookmarks/index.html.erb
@@ -3,7 +3,7 @@
 <div id="bookmark-index" class="container">
   <h1 class="text-center mt-3">ブックマーク一覧</h1>
   <div id="bookmark-index__row" class="row justify-content-center align-items-center">
-    <div id="bookmark-index__column" class="col-md-10">
+    <div id="bookmark-index__column" class="col-md-10 mb-4">
       <%= turbo_frame_tag @category do %>
         <%= link_to new_category_path, class: "d-block text-center mb-4" do %>
         <i class="bi bi-plus-lg" aria-hidden="true"></i> カテゴリー作成

--- a/app/views/bookmarks/index.html.erb
+++ b/app/views/bookmarks/index.html.erb
@@ -6,7 +6,7 @@
     <div id="bookmark-index__column" class="col-md-10">
       <%= turbo_frame_tag @category do %>
         <%= link_to new_category_path, class: "d-block text-center mb-4" do %>
-        <i class="bi bi-pencil-fill"></i> カテゴリー作成
+        <i class="bi bi-plus-lg" aria-hidden="true"></i> カテゴリー作成
         <% end %>
       <% end %>
 

--- a/app/views/bookmarks/index.html.erb
+++ b/app/views/bookmarks/index.html.erb
@@ -1,14 +1,16 @@
 <% content_for(:title, "ブックマーク一覧") %>
 <%= turbo_page_requires_reload %>
 <div id="bookmark-index" class="container">
-  <h1 class="text-center mt-3 mb-4">ブックマーク一覧</h1>
+  <h1 class="text-center mt-3">ブックマーク一覧</h1>
   <div id="bookmark-index__row" class="row justify-content-center align-items-center">
     <div id="bookmark-index__column" class="col-md-10">
-      <%= render 'shared/categories', { categories: @user.categories } %>
-
       <%= turbo_frame_tag @category do %>
-        <%= link_to "作成", new_category_path, class: "d-block text-center" %>
+        <%= link_to new_category_path, class: "d-block text-center mb-4" do %>
+        <i class="bi bi-pencil-fill"></i> カテゴリー作成
+        <% end %>
       <% end %>
+
+      <%= render 'shared/categories', { categories: @user.categories } %>
 
       <%= turbo_frame_tag "bookmarks-list", autoscroll: true, data: { autoscroll_block: "start" } do %>
         <div id="bookmark__row" class="row d-flex justify-content-center align-items-start">

--- a/app/views/bookmarks/new.html.erb
+++ b/app/views/bookmarks/new.html.erb
@@ -25,7 +25,7 @@
                 <%= f.label :category, "カテゴリー", class: "d-block mb-1" %>
                 <%= f.collection_check_boxes(:category_ids, @user.categories, :id, :name) do |category| %>
                   <%= category.check_box class: "btn-check" %>
-                  <%= category.label class: "bookmark-new__category-button btn" do %>
+                  <%= category.label class: "bookmark-new__category-button btn shadow-sm" do %>
                     <%= category.text %>
                   <% end %>
                 <% end %>
@@ -49,7 +49,7 @@
           <%= f.hidden_field :user_id, value: @user.id %>
 
           <div class="bookmark-new__form-group-action mb-3">
-            <%= f.submit "登録", class: "bookmark-new__button btn mb-5" %>
+            <%= f.submit "登録", class: "bookmark-new__button btn shadow-sm mb-5" %>
           </div>
         <% end %>
       </div>

--- a/app/views/bookmarks/show.html.erb
+++ b/app/views/bookmarks/show.html.erb
@@ -37,9 +37,12 @@
       <% if @user.present? && @bookmark.user_id == @user.id %>
         <%= render 'shared/timestamps_new', { timestamp: @timestamp, bookmark: @bookmark } %>
         <div class="bookmark-show__link mt-2">
-          <%= link_to "編集", edit_bookmark_path(@bookmark) %> / <%= link_to "削除",
-                                                                     bookmark_path(@bookmark),
-                                                                     data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" } %>
+          <%= link_to edit_bookmark_path(@bookmark) do %>
+            <i class="bi bi-pencil-fill mx-2" alt="ブックマークの編集"></i>
+          <% end %>
+          <%= link_to bookmark_path(@bookmark), data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" } do %>
+            <i class="bi bi-trash3-fill" alt="ブックマークの削除"></i>
+          <% end %>
         </div>
       <% end %>
     </div>

--- a/app/views/bookmarks/show.html.erb
+++ b/app/views/bookmarks/show.html.erb
@@ -6,8 +6,8 @@
 
       <%= render 'shared/error_messages', obj: @timestamp %>
 
-      <div id="bookmark-video">
-        <iframe src="https://www.youtube.com/embed/<%= @bookmark.video_id %>" class="youtube-video-player" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+      <div id="bookmark-video" class="ratio ratio-16x9">
+        <iframe src="https://www.youtube.com/embed/<%= @bookmark.video_id %>" class="youtube-video-player" title="YouTube video player" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
       </div>
 
       <div class="accordion mt-1 mb-3" id="accordionExample">

--- a/app/views/bookmarks/show.html.erb
+++ b/app/views/bookmarks/show.html.erb
@@ -42,10 +42,6 @@
                                                                      data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" } %>
         </div>
       <% end %>
-
-      <div class="bookmark-show__back mt-5">
-        <%= link_to "戻る", "javascript:history.back()" %>
-      </div>
     </div>
   </div>
 </div>

--- a/app/views/bookmarks/show.html.erb
+++ b/app/views/bookmarks/show.html.erb
@@ -1,6 +1,6 @@
 <% content_for(:title, video_title(@bookmark.video_id)) %>
 <%= turbo_page_requires_reload %>
-<div id="bookmark-show" class="container">
+<div id="bookmark-show" class="container mb-4">
   <div id="bookmark-show__row" class="row justify-content-center align-items-center">
     <div id="bookmark-show__column" class="col-lg-8 col-md-10 mb-4">
 

--- a/app/views/bookmarks/show.html.erb
+++ b/app/views/bookmarks/show.html.erb
@@ -38,10 +38,10 @@
         <%= render 'shared/timestamps_new', { timestamp: @timestamp, bookmark: @bookmark } %>
         <div class="bookmark-show__link mt-2">
           <%= link_to edit_bookmark_path(@bookmark) do %>
-            <i class="bi bi-pencil-fill mx-2" alt="ブックマークの編集"></i>
+            <i class="bi bi-pencil-fill mx-1" aria-label="ブックマークの編集"></i>
           <% end %>
           <%= link_to bookmark_path(@bookmark), data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" } do %>
-            <i class="bi bi-trash3-fill" alt="ブックマークの削除"></i>
+            <i class="bi bi-trash3-fill mx-1" aria-label="ブックマークの削除"></i>
           <% end %>
         </div>
       <% end %>

--- a/app/views/categories/show.html.erb
+++ b/app/views/categories/show.html.erb
@@ -3,7 +3,7 @@
 <div id="categories-show" class="container">
   <h1 class="text-center mt-3"><%= @category.name %></h1>
   <div id="categories-show__row" class="row justify-content-center align-items-center">
-    <div id="categories-show__column" class="col-md-10">
+    <div id="categories-show__column" class="col-md-10 mb-4">
       <%= turbo_frame_tag @category do %>
         <div class="text-center mb-4">
           <%= link_to edit_category_path(@category), class: "category__edit-link" do %>

--- a/app/views/categories/show.html.erb
+++ b/app/views/categories/show.html.erb
@@ -1,14 +1,16 @@
 <% content_for(:title, @category.name) %>
 <%= turbo_page_requires_reload %>
 <div id="categories-show" class="container">
-  <h1 class="text-center mt-3 mb-4"><%= @category.name %></h1>
+  <h1 class="text-center mt-3"><%= @category.name %></h1>
   <div id="categories-show__row" class="row justify-content-center align-items-center">
     <div id="categories-show__column" class="col-md-10">
-      <%= render 'shared/categories', { categories: @categories } %>
-
       <%= turbo_frame_tag @category do %>
-        <%= link_to "編集", edit_category_path(@category), class: "d-block text-center" %>
+        <%= link_to edit_category_path(@category), class: "d-block text-center mb-4" do %>
+        <i class="bi bi-pencil-fill"></i> 編集
+        <% end %>
       <% end %>
+
+      <%= render 'shared/categories', { categories: @categories } %>
 
       <%= turbo_frame_tag "bookmarks-list", autoscroll: true, data: { autoscroll_block: "start" } do %>
         <% if @category.bookmarks.present? %>

--- a/app/views/categories/show.html.erb
+++ b/app/views/categories/show.html.erb
@@ -6,10 +6,11 @@
     <div id="categories-show__column" class="col-md-10">
       <%= turbo_frame_tag @category do %>
         <div class="text-center mb-4">
-          <%= link_to edit_category_path(@category) do %>
+          <%= link_to edit_category_path(@category), class: "category__edit-link" do %>
           <i class="bi bi-pencil-fill mx-2" aria-label="カテゴリー名の編集"></i>
           <% end %>
           <%= link_to category_path(@category),
+                      class: "category__delete-link",
                       data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" } do %>
             <i class="bi bi-trash3-fill mx-2" aria-label="カテゴリーの削除"></i>
           <% end %>

--- a/app/views/categories/show.html.erb
+++ b/app/views/categories/show.html.erb
@@ -5,9 +5,15 @@
   <div id="categories-show__row" class="row justify-content-center align-items-center">
     <div id="categories-show__column" class="col-md-10">
       <%= turbo_frame_tag @category do %>
-        <%= link_to edit_category_path(@category), class: "d-block text-center mb-4" do %>
-        <i class="bi bi-pencil-fill"></i> 編集
-        <% end %>
+        <div class="text-center mb-4">
+          <%= link_to edit_category_path(@category) do %>
+          <i class="bi bi-pencil-fill"></i> 編集
+          <% end %>/
+          <%= link_to category_path(@category),
+                      data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" } do %>
+            <i class="bi bi-trash3-fill"></i> 削除
+          <% end %>
+        </div>
       <% end %>
 
       <%= render 'shared/categories', { categories: @categories } %>

--- a/app/views/categories/show.html.erb
+++ b/app/views/categories/show.html.erb
@@ -7,11 +7,11 @@
       <%= turbo_frame_tag @category do %>
         <div class="text-center mb-4">
           <%= link_to edit_category_path(@category) do %>
-          <i class="bi bi-pencil-fill"></i> 編集
-          <% end %>/
+          <i class="bi bi-pencil-fill mx-2" aria-label="カテゴリー名の編集"></i>
+          <% end %>
           <%= link_to category_path(@category),
                       data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" } do %>
-            <i class="bi bi-trash3-fill"></i> 削除
+            <i class="bi bi-trash3-fill mx-2" aria-label="カテゴリーの削除"></i>
           <% end %>
         </div>
       <% end %>

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -25,7 +25,7 @@
           </div>
 
           <div class="password-edit__form-group mb-3">
-            <%= f.submit "パスワードを変更する", class: "btn mt-2 mb-1 password-edit__button" %>
+            <%= f.submit "パスワードを変更する", class: "btn shadow-sm mt-2 mb-1 password-edit__button" %>
           </div>
         <% end %>
       </div>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -18,9 +18,6 @@
           </div>
         <% end %>
       </div>
-      <div class="password-new__back-link">
-        <%= link_to "戻る", "javascript:history.back()" %>
-      </div>
     </div>
   </div>
 </div>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -14,7 +14,7 @@
           </div>
 
           <div class="password-new__form-group mb-3">
-            <%= f.submit "パスワード再設定メールを送信", class: "btn mt-2 mb-1 password-new__button" %>
+            <%= f.submit "パスワード再設定メールを送信", class: "btn shadow-sm mt-2 mb-1 password-new__button" %>
           </div>
         <% end %>
       </div>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -28,7 +28,7 @@
           </div>
 
           <div class="user-edit__form-group-action justify-content-between align-items-center d-flex">
-            <%= f.submit "変更", class: "btn mt-2 mb-2 user-edit__button" %>
+            <%= f.submit "変更", class: "btn shadow-sm mt-2 mb-2 user-edit__button" %>
             <%= link_to "退会する", users_confirm_path, class: "d-inline" %>
           </div>
         <% end %>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -33,9 +33,6 @@
           </div>
         <% end %>
       </div>
-      <div class="user-edit__back-link">
-        <%= link_to "戻る", "javascript:history.back()" %>
-      </div>
     </div>
   </div>
 </div>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -27,7 +27,7 @@
           </div>
 
           <div class="registration__form-group-action">
-            <%= f.submit "登録", class: "btn mt-2 mb-1 registration__button" %>
+            <%= f.submit "登録", class: "btn shadow-sm mt-2 mb-1 registration__button" %>
           </div>
         <% end %>
       </div>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -31,9 +31,6 @@
           </div>
         <% end %>
       </div>
-      <div class="registration__back-link">
-        <%= link_to "戻る", "javascript:history.back()" %>
-      </div>
     </div>
   </div>
 </div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -21,7 +21,7 @@
               <%= f.label :remember_me, "自動ログイン" %>
             <% end %>
             <br>
-            <%= f.submit "ログイン", class: "btn mt-3 login__button" %>
+            <%= f.submit "ログイン", class: "btn shadow-sm mt-3 login__button" %>
           </div>
 
           <div class="login__link">

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -30,9 +30,6 @@
           </div>
         <% end %>
       </div>
-      <div class="login__back-link">
-        <%= link_to "戻る", "javascript:history.back()" %>
-      </div>
     </div>
   </div>
 </div>

--- a/app/views/devise/shared/_error_messages.html.erb
+++ b/app/views/devise/shared/_error_messages.html.erb
@@ -2,7 +2,7 @@
   <div class="devise__error-messages my-3 text-center" data-turbo-cache="false">
     <ul>
       <% resource.errors.full_messages.each do |message| %>
-        <li><%= message %></li>
+        <li><i class="bi bi-exclamation-triangle"></i> <%= message %></li>
       <% end %>
     </ul>
   </div>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -41,13 +41,15 @@
             </table>
           </div>
         </div>
-        <div class="firstview__login d-grid gap-2 d-md-block">
-          <%= link_to "登録せずに使う（ゲストログイン）",
-                      users_guest_sign_in_path,
-                      data: { turbo_method: :post },
-                      class: "btn btn-light shadow-sm mx-2" %>
-          <%= link_to "新規登録", new_user_registration_path, class: "btn shadow-sm mx-1 header__registration-button mx-2" %>
-        </div>
+        <% unless user_signed_in? %>
+          <div class="firstview__login d-grid gap-2 d-md-block">
+            <%= link_to "登録せずに使う（ゲストログイン）",
+                        users_guest_sign_in_path,
+                        data: { turbo_method: :post },
+                        class: "btn btn-light shadow-sm mx-2" %>
+            <%= link_to "新規登録", new_user_registration_path, class: "btn shadow-sm mx-1 header__registration-button mx-2" %>
+          </div>
+        <% end %>
       </div>
     </div>
   </div>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,21 +1,28 @@
 <div id="firstview" class="container px-4">
   <h1 class="firstview-title text-center mb-5">推しTube</h1>
   <div id="firstview__row" class="row justify-content-center align-items-center">
-    <div id="firstview__column" class="col-md-10">
-      <div class="firstview__introduction text-center lh-base">
-        推しTubeは<span class="fw-semibold">時間指定のできるYouTubeブックマーク</span>です。<br>
-        動画URLと再生を開始したい時間を登録すれば、<br>
-        ボタン1つで見たい時間から何度でも再生できます。<br>
-        <br>
-        <span class="lh-lg">
-          <i class="bi bi-check-lg"></i> 推しのこの瞬間を何度でも見たい！<br>
-          <i class="bi bi-check-lg"></i> この曲のサビの部分を何度でも見たい！<br>
-          <i class="bi bi-check-lg"></i> 勉強中にこの動画のこの部分を何度も見て復習したい！<br>
-        </span>
-        <br>
-        そんなときにぜひご活用ください！<br>
-        <br>
-        <%= button_to "登録せずに使う（ゲストログイン）", users_guest_sign_in_path, data: { turbo_method: :post }, class: "btn btn-light shadow-sm" %>
+    <div id="firstview__column" class="col-md-8 mb-4">
+      <div class="firstview__introduction-container text-center lh-base">
+        <div class="firstview__introduction-text mb-5">
+          推しTubeは<span class="fw-semibold">時間指定のできるYouTubeブックマーク</span>です。<br>
+          動画URLと再生を開始したい時間を登録すれば、<br>
+          ボタン1つで見たい時間から何度でも再生できます。<br>
+          <br>
+          <span class="lh-lg">
+            <i class="bi bi-check-lg"></i> 推しのこの瞬間を何度でも見たい！<br>
+            <i class="bi bi-check-lg"></i> この曲のサビの部分を何度でも見たい！<br>
+            <i class="bi bi-check-lg"></i> 勉強中にこの動画のこの部分を何度も見て復習したい！<br>
+          </span>
+          <br>
+          そんなときにぜひご活用ください！
+        </div>
+        <div id="firstview-video" class="ratio ratio-16x9 mb-2">
+          <iframe width="560" height="315" src="https://www.youtube.com/embed/Tkr-itfalqw?si=FddAGxwCAOJHnSTt" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+        </div>
+        <%= button_to "登録せずに使う（ゲストログイン）",
+                      users_guest_sign_in_path,
+                      data: { turbo_method: :post },
+                      class: "btn btn-light shadow-sm" %>
       </div>
     </div>
   </div>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -27,15 +27,15 @@
           <div class="firstview__introduction-table mb-5">
             <table>
               <tr>
-                <td><button id="firstview-button0" class="btn timestamps__button shadow-sm mx-4 my-1">0:0:8</button></td>
+                <td><button id="firstview-button0" class="btn timestamps__button shadow-sm me-4 my-1">0:0:8</button></td>
                 <td> ブックマーク登録</td>
               </tr>
               <tr>
-                <td><button id="firstview-button1" class="btn timestamps__button shadow-sm mx-4 my-1">0:0:32</button></td>
+                <td><button id="firstview-button1" class="btn timestamps__button shadow-sm me-4 my-1">0:0:32</button></td>
                 <td> タイムスタンプ登録</td>
               </tr>
               <tr>
-                <td><button id="firstview-button2" class="btn timestamps__button shadow-sm mx-4 my-1">0:0:55</button></td>
+                <td><button id="firstview-button2" class="btn timestamps__button shadow-sm me-4 my-1">0:0:55</button></td>
                 <td> カテゴリー作成・登録</td>
               </tr>
             </table>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,7 +1,7 @@
 <div id="firstview" class="container px-4">
   <h1 class="firstview-title text-center mb-5">推しTube</h1>
   <div id="firstview__row" class="row justify-content-center align-items-center">
-    <div id="firstview__column" class="col-md-8 mb-4">
+    <div id="firstview__column" class="col-md-6 mb-4">
       <div class="firstview__introduction-container text-center lh-base">
         <div class="firstview__introduction-text mb-5">
           推しTubeは<span class="fw-semibold">時間指定のできるYouTubeブックマーク</span>です。<br>
@@ -16,8 +16,30 @@
           <br>
           そんなときにぜひご活用ください！
         </div>
-        <div id="firstview-video" class="ratio ratio-16x9 mb-2">
-          <iframe width="560" height="315" src="https://www.youtube.com/embed/Tkr-itfalqw?si=FddAGxwCAOJHnSTt" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+        <div class="firstview__introduction">
+          <div class="firstview__video-title fw-semibold mb-1">
+            推しTubeの使い方<br>
+            （音量にご注意ください）
+          </div>
+          <div id="firstview-video" class="ratio ratio-16x9 mb-2">
+            <iframe width="560" height="315" src="https://www.youtube.com/embed/Tkr-itfalqw?si=FddAGxwCAOJHnSTt" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+          </div>
+          <div class="firstview__introduction-table mb-5">
+            <table>
+              <tr>
+                <td><button id="firstview-button0" class="btn timestamps__button shadow-sm mx-4 my-1">0:0:8</button></td>
+                <td> ブックマーク登録</td>
+              </tr>
+              <tr>
+                <td><button id="firstview-button1" class="btn timestamps__button shadow-sm mx-4 my-1">0:0:32</button></td>
+                <td> タイムスタンプ登録</td>
+              </tr>
+              <tr>
+                <td><button id="firstview-button2" class="btn timestamps__button shadow-sm mx-4 my-1">0:0:55</button></td>
+                <td> カテゴリー作成・登録</td>
+              </tr>
+            </table>
+          </div>
         </div>
         <%= button_to "登録せずに使う（ゲストログイン）",
                       users_guest_sign_in_path,

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,4 +1,8 @@
-<div class="firstview-container container">
-  <h1 class="firstview-title">推しTube（仮）</h1>
-  <%= button_to "ゲストログイン", users_guest_sign_in_path, data: { turbo_method: :post }, class: "btn btn-light" %>
+<div id="firstview" class="container">
+  <h1 class="firstview-title">推しTube</h1>
+  <div id="firstview__row" class="row justify-content-center align-items-center">
+    <div id="firstview__column" class="col-md-10">
+      <%= button_to "ゲストログイン", users_guest_sign_in_path, data: { turbo_method: :post }, class: "btn btn-light" %>
+    </div>
+  </div>
 </div>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -2,7 +2,7 @@
   <h1 class="firstview-title">推しTube</h1>
   <div id="firstview__row" class="row justify-content-center align-items-center">
     <div id="firstview__column" class="col-md-10">
-      <%= button_to "ゲストログイン", users_guest_sign_in_path, data: { turbo_method: :post }, class: "btn btn-light" %>
+      <%= button_to "ゲストログイン", users_guest_sign_in_path, data: { turbo_method: :post }, class: "btn btn-light shadow-sm" %>
     </div>
   </div>
 </div>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,8 +1,22 @@
-<div id="firstview" class="container">
-  <h1 class="firstview-title">推しTube</h1>
+<div id="firstview" class="container px-4">
+  <h1 class="firstview-title text-center mb-5">推しTube</h1>
   <div id="firstview__row" class="row justify-content-center align-items-center">
     <div id="firstview__column" class="col-md-10">
-      <%= button_to "ゲストログイン", users_guest_sign_in_path, data: { turbo_method: :post }, class: "btn btn-light shadow-sm" %>
+      <div class="firstview__introduction text-center lh-base">
+        推しTubeは<span class="fw-semibold">時間指定のできるYouTubeブックマーク</span>です。<br>
+        動画URLと再生を開始したい時間を登録すれば、<br>
+        ボタン1つで見たい時間から何度でも再生できます。<br>
+        <br>
+        <span class="lh-lg">
+          <i class="bi bi-check-lg"></i> 推しのこの瞬間を何度でも見たい！<br>
+          <i class="bi bi-check-lg"></i> この曲のサビの部分を何度でも見たい！<br>
+          <i class="bi bi-check-lg"></i> 勉強中にこの動画のこの部分を何度も見て復習したい！<br>
+        </span>
+        <br>
+        そんなときにぜひご活用ください！<br>
+        <br>
+        <%= button_to "登録せずに使う（ゲストログイン）", users_guest_sign_in_path, data: { turbo_method: :post }, class: "btn btn-light shadow-sm" %>
+      </div>
     </div>
   </div>
 </div>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,7 +1,7 @@
-<div id="firstview" class="container px-4">
+<div id="firstview" class="container px-4 mb-4">
   <h1 class="firstview-title text-center mb-5">推しTube</h1>
   <div id="firstview__row" class="row justify-content-center align-items-center">
-    <div id="firstview__column" class="col-md-6 mb-4">
+    <div id="firstview__column" class="col-lg-6 col-md-8 mb-4">
       <div class="firstview__introduction-container text-center lh-base">
         <div class="firstview__introduction-text mb-5">
           推しTubeは<span class="fw-semibold">時間指定のできるYouTubeブックマーク</span>です。<br>
@@ -41,10 +41,13 @@
             </table>
           </div>
         </div>
-        <%= button_to "登録せずに使う（ゲストログイン）",
+        <div class="firstview__login d-grid gap-2 d-md-block">
+          <%= link_to "登録せずに使う（ゲストログイン）",
                       users_guest_sign_in_path,
                       data: { turbo_method: :post },
-                      class: "btn btn-light shadow-sm" %>
+                      class: "btn btn-light shadow-sm mx-2" %>
+          <%= link_to "新規登録", new_user_registration_path, class: "btn shadow-sm mx-1 header__registration-button mx-2" %>
+        </div>
       </div>
     </div>
   </div>

--- a/app/views/shared/_categories.html.erb
+++ b/app/views/shared/_categories.html.erb
@@ -2,9 +2,9 @@
   <div id="categories__column" class="col-md-6 text-center">
     <% if categories.present? %>
       <% categories.each do |category| %>
-        <%= link_to category.name, category_path(category), class: "categories__button btn mx-1 my-1" %>
+        <%= link_to category.name, category_path(category), class: "categories__button btn shadow-sm mx-1 my-1" %>
       <% end %>
     <% end %>
-    <%= link_to "すべてのブックマーク", bookmarks_path, class: "categories__button btn mx-1 my-1" %>
+    <%= link_to "すべてのブックマーク", bookmarks_path, class: "categories__button btn shadow-sm mx-1 my-1" %>
   </div>
 </div>

--- a/app/views/shared/_categories_edit.html.erb
+++ b/app/views/shared/_categories_edit.html.erb
@@ -2,9 +2,7 @@
   <div class="categories-edit__form-group text-center col-lg-4 col-sm-6">
     <%= form_with model: category do |f| %>
       <%= f.label :name, "カテゴリー名" %>
-      <div class="bookmark-edit__flash-message error-messages mt-3 text-center">
-        <%= flash[:edit_error_message] %>
-      </div>
+      <%= render 'shared/error_messages', obj: category %>
       <%= f.text_field :name, class: "form-control justify-content-center align-items-center" %>
       <%= f.hidden_field :user_id, value: user.id %>
       <%= f.submit "編集", class: "categories-edit__button btn shadow-sm mt-1" %>

--- a/app/views/shared/_categories_edit.html.erb
+++ b/app/views/shared/_categories_edit.html.erb
@@ -8,10 +8,6 @@
       <%= f.text_field :name, class: "form-control justify-content-center align-items-center" %>
       <%= f.hidden_field :user_id, value: user.id %>
       <%= f.submit "編集", class: "categories-edit__button btn mt-1" %>
-      <%= link_to "削除",
-          category_path(category),
-          data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" },
-          class: "categories-edit__delete-button btn mt-1" %>
     <% end %>
   </div>
 </div>

--- a/app/views/shared/_categories_edit.html.erb
+++ b/app/views/shared/_categories_edit.html.erb
@@ -7,7 +7,7 @@
       </div>
       <%= f.text_field :name, class: "form-control justify-content-center align-items-center" %>
       <%= f.hidden_field :user_id, value: user.id %>
-      <%= f.submit "編集", class: "categories-edit__button btn mt-1" %>
+      <%= f.submit "編集", class: "categories-edit__button btn shadow-sm mt-1" %>
     <% end %>
   </div>
 </div>

--- a/app/views/shared/_categories_new.html.erb
+++ b/app/views/shared/_categories_new.html.erb
@@ -5,7 +5,7 @@
       <%= render 'shared/error_messages', obj: category %>
       <%= f.text_field :name, class: "form-control justify-content-center align-items-center" %>
       <%= f.hidden_field :user_id, value: user.id %>
-      <%= f.submit "作成", class: "categories-new__button btn mt-1" %>
+      <%= f.submit "作成", class: "categories-new__button btn shadow-sm mt-1" %>
     <% end %>
   </div>
 </div>

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -2,7 +2,7 @@
   <div class="error-messages my-3 text-center">
     <ul>
       <% obj.errors.full_messages.each do |message| %>
-        <li><%= message %></li>
+        <li><i class="bi bi-exclamation-triangle"></i> <%= message %></li>
       <% end %>
     </ul>
   </div>

--- a/app/views/shared/_flash_messages.html.erb
+++ b/app/views/shared/_flash_messages.html.erb
@@ -1,3 +1,3 @@
-<div class="flash-messages my-3 text-center">
+<div class="flash-messages mt-3 mb-5 text-center">
   <p class="notice"><%= notice %></p>
 </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -4,7 +4,16 @@
   </div>
 
   <% if user_signed_in? %>
-    <div class="header__dropdown dropdown">
+    <div class="header__dropdown--pc">
+      <%= link_to "ブックマーク登録", new_bookmark_path, class: "btn" %>
+      <%= link_to "ブックマーク一覧", bookmarks_path, class: "btn" %>
+      <%= link_to "プロフィール", user_path(user.id), class: "btn" %>
+      <%= link_to "ログアウト",
+        destroy_user_session_path,
+        method: :delete,
+        data: { turbo_method: :delete }, class: "btn" %>
+    </div>
+    <div class="header__dropdown--mobile dropdown">
       <a class="btn dropdown-toggle header__dropdown-menu-button shadow-sm" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
         <span>メニュー</span>
       </a>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,6 +1,6 @@
 <div class="header">
   <div class="header__title">
-    <span><%= link_to "推しTube（仮）", root_path %></span>
+    <span><%= link_to "推しTube", root_path %></span>
   </div>
 
   <% if user_signed_in? %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,4 +1,4 @@
-<div class="header">
+<div class="header shadow-sm">
   <div class="header__title">
     <span><%= link_to "推しTube", root_path %></span>
   </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -9,10 +9,13 @@
         <span>メニュー</span>
       </a>
       <ul class="header__dropdown-menu dropdown-menu">
-        <li><%= link_to "ブックマーク登録", new_bookmark_path %></li>
-        <li><%= link_to "ブックマーク一覧", bookmarks_path %></li>
-        <li><%= link_to "プロフィール", user_path(user.id) %></li>
-        <li><%= link_to "ログアウト", destroy_user_session_path, method: :delete, data: { turbo_method: :delete } %></li>
+        <li class="mx-1"><%= link_to "ブックマーク登録", new_bookmark_path, class: "btn" %></li>
+        <li class="mx-1 mb-2"><%= link_to "ブックマーク一覧", bookmarks_path, class: "btn" %></li>
+        <li class="mx-1"><%= link_to "プロフィール", user_path(user.id), class: "btn" %></li>
+        <li class="mx-1"><%= link_to "ログアウト",
+                             destroy_user_session_path,
+                             method: :delete,
+                             data: { turbo_method: :delete }, class: "btn" %></li>
       </ul>
     </div>
   <% else %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -5,7 +5,7 @@
 
   <% if user_signed_in? %>
     <div class="header__dropdown dropdown">
-      <a class="btn dropdown-toggle header__dropdown-menu-button" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+      <a class="btn dropdown-toggle header__dropdown-menu-button shadow-sm" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
         <span>メニュー</span>
       </a>
       <ul class="header__dropdown-menu dropdown-menu">
@@ -17,8 +17,8 @@
     </div>
   <% else %>
     <div class="header__link">
-      <%= link_to "新規登録", new_user_registration_path, class: "btn mx-1 header__registration-button" %>
-      <%= link_to "ログイン", new_user_session_path, class: "btn mx-1 header__login-button" %>
+      <%= link_to "新規登録", new_user_registration_path, class: "btn shadow-sm mx-1 header__registration-button" %>
+      <%= link_to "ログイン", new_user_session_path, class: "btn shadow-sm mx-1 header__login-button" %>
     </div>
   <% end %>
 </div>

--- a/app/views/shared/_timestamps_edit.html.erb
+++ b/app/views/shared/_timestamps_edit.html.erb
@@ -24,7 +24,7 @@
     </div>
 
     <%= f.hidden_field :bookmark_id, value: timestamp.bookmark.id %>
-    <%= f.submit "登録", class: "timestamps-edit__button btn my-3" %>
-    <%= link_to "キャンセル", timestamp, class: "timestamps-edit__button btn my-3" %>
+    <%= f.submit "登録", class: "timestamps-edit__button btn shadow-sm my-3" %>
+    <%= link_to "キャンセル", timestamp, class: "timestamps-edit__button btn shadow-sm my-3" %>
   <% end %>
 </div>

--- a/app/views/shared/_timestamps_list.html.erb
+++ b/app/views/shared/_timestamps_list.html.erb
@@ -12,12 +12,14 @@
         </td>
         <% if user.present? && timestamp.bookmark.user_id == user.id %>
           <td class="timestamps__td3">
-            <%= link_to edit_timestamp_path(timestamp) do %>
+            <%= link_to edit_timestamp_path(timestamp), class: "timestamp__edit-link" do %>
               <i class="bi bi-pencil-fill mx-1" aria-label="タイムスタンプの編集"></i>
             <% end %>
           </td>
           <td class="timestamps__td4">
-            <%= link_to timestamp_path(timestamp), data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" } do %>
+            <%= link_to timestamp_path(timestamp),
+                        class: "timestamp__delete-link",
+                        data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" } do %>
               <i class="bi bi-trash3-fill mx-1" aria-label="タイムスタンプの削除"></i>
             <% end %>
           </td>

--- a/app/views/shared/_timestamps_list.html.erb
+++ b/app/views/shared/_timestamps_list.html.erb
@@ -12,10 +12,14 @@
         </td>
         <% if user.present? && timestamp.bookmark.user_id == user.id %>
           <td class="timestamps__td3">
-            <%= link_to "編集", edit_timestamp_path(timestamp) %>
+            <%= link_to edit_timestamp_path(timestamp) do %>
+              <i class="bi bi-pencil-fill mx-2" alt="タイムスタンプの編集"></i>
+            <% end %>
           </td>
           <td class="timestamps__td4">
-            <%= link_to "削除", timestamp_path(timestamp), data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" } %>
+            <%= link_to timestamp_path(timestamp), data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" } do %>
+              <i class="bi bi-trash3-fill" alt="タイムスタンプの削除"></i>
+            <% end %>
           </td>
         <% end %>
       </tr>

--- a/app/views/shared/_timestamps_list.html.erb
+++ b/app/views/shared/_timestamps_list.html.erb
@@ -13,12 +13,12 @@
         <% if user.present? && timestamp.bookmark.user_id == user.id %>
           <td class="timestamps__td3">
             <%= link_to edit_timestamp_path(timestamp) do %>
-              <i class="bi bi-pencil-fill mx-2" alt="タイムスタンプの編集"></i>
+              <i class="bi bi-pencil-fill mx-1" aria-label="タイムスタンプの編集"></i>
             <% end %>
           </td>
           <td class="timestamps__td4">
             <%= link_to timestamp_path(timestamp), data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" } do %>
-              <i class="bi bi-trash3-fill" alt="タイムスタンプの削除"></i>
+              <i class="bi bi-trash3-fill mx-1" aria-label="タイムスタンプの削除"></i>
             <% end %>
           </td>
         <% end %>

--- a/app/views/shared/_timestamps_list.html.erb
+++ b/app/views/shared/_timestamps_list.html.erb
@@ -3,7 +3,7 @@
     <table class="timestamps-table timestamps-table-<%= "#{timestamps.index(timestamp)}" %>">
       <tr>
         <td class="timestamps__td1">
-          <button class="timestamps__button btn text-nowrap me-2" id="<%= "timestamp-#{timestamps.index(timestamp)}" %>">
+          <button class="timestamps__button btn shadow-sm text-nowrap me-2" id="<%= "timestamp-#{timestamps.index(timestamp)}" %>">
             <%= timestamp.hour %> : <%= timestamp.minute %> : <%= timestamp.second %>
           </button>
         </td>

--- a/app/views/shared/_timestamps_new.html.erb
+++ b/app/views/shared/_timestamps_new.html.erb
@@ -23,6 +23,6 @@
     </div>
 
     <%= f.hidden_field :bookmark_id, value: bookmark.id %>
-    <%= f.submit "登録", class: "timestamps-new__button btn my-3" %>
+    <%= f.submit "登録", class: "timestamps-new__button btn shadow-sm my-3" %>
   <% end %>
 </div>

--- a/app/views/users/confirm.html.erb
+++ b/app/views/users/confirm.html.erb
@@ -11,8 +11,8 @@
       <div class="user-confirm__link text-center d-grid gap-2 d-md-block">
         <%= link_to "退会する", users_withdrawal_path,
             data: { turbo_method: :patch, turbo_confirm: "本当に退会しますか？" },
-            class: "user-confirm__withdrawal-button btn mx-3" %>
-        <%= link_to "退会しない（プロフィールに戻る）", user_path(@user), class: "user-confirm__back-button btn mx-3" %>
+            class: "user-confirm__withdrawal-button btn shadow-sm mx-3" %>
+        <%= link_to "退会しない（プロフィールに戻る）", user_path(@user), class: "user-confirm__back-button btn shadow-sm mx-3" %>
       </div>
     </div>
   </div>

--- a/app/views/users/profile_edit.html.erb
+++ b/app/views/users/profile_edit.html.erb
@@ -3,14 +3,7 @@
   <h1 class="text-center pt-4">プロフィール編集</h1>
   <div id="profile-edit__row" class="row justify-content-center align-items-center">
     <div id="profile-edit__column" class="col-lg-6 col-md-8">
-      <% if @user.errors.any? %>
-        <ul>
-          <% @user.errors.full_messages.each do |message| %>
-            <li><%= message %></li>
-          <% end %>
-        </ul>
-      <% end %>
-
+      <%= render "shared/error_messages", obj: @user %>
       <div id="profile-edit__box">
         <%= form_with(model: @user, id: "profile-edit__form", class: "form", url: profile_edit_path, method: :post) do |f| %>
 

--- a/app/views/users/profile_edit.html.erb
+++ b/app/views/users/profile_edit.html.erb
@@ -30,7 +30,7 @@
           </div>
 
           <div class="profile-edit__form-group-action">
-            <%= f.submit "変更", class: "btn mt-2 mb-1 profile-edit__button" %>
+            <%= f.submit "変更", class: "btn shadow-sm mt-2 mb-1 profile-edit__button" %>
           </div>
         <% end %>
       </div>

--- a/app/views/users/profile_edit.html.erb
+++ b/app/views/users/profile_edit.html.erb
@@ -34,9 +34,6 @@
           </div>
         <% end %>
       </div>
-      <div class="profile-edit__back-link">
-        <%= link_to "戻る", "javascript:history.back()" %>
-      </div>
     </div>
   </div>
 </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,7 +1,7 @@
 <% content_for(:title, @user.name) %>
 <div id="profile-show" class="container">
   <div id="profile-show__row" class="row justify-content-center align-items-center">
-    <div id="profile-show__column" class="col-md-10">
+    <div id="profile-show__column" class="col-md-10 mb-4">
       <div class="profile-show__user text-center mb-4">
         <% if @user.icon.present? %>
           <%= image_tag @user.icon, class: "profile-show__icon d-block mt-3 mb-1" %>

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -6,5 +6,6 @@ pin "@hotwired/stimulus", to: "stimulus.min.js"
 pin "@hotwired/stimulus-loading", to: "stimulus-loading.js"
 pin_all_from "app/javascript/controllers", under: "controllers"
 pin "bookmarks/timestamps"
+pin "home/timestamps"
 pin "bootstrap", to: "bootstrap.min.js", preload: true
 pin "@popperjs/core", to: "popper.js", preload: true

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -1,0 +1,4 @@
+ja:
+  devise:
+    passwords:
+      send_instructions: "パスワード再設定用のメールを送信しました。"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,6 @@
 Rails.application.routes.draw do
   devise_for :users, controllers: {
+    registrations: "users/registrations",
     sessions: "users/sessions"
   }
   devise_scope :user do

--- a/spec/system/bookmarks_spec.rb
+++ b/spec/system/bookmarks_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe "Bookmarks", type: :system do
 
       it "編集ページへのリンクが表示されること" do
         visit bookmark_path(bookmark)
-        expect(page).to have_content "編集"
+        expect(page).to have_selector "i[aria-label='ブックマークの編集']"
       end
 
       it "編集ページが表示できること" do
@@ -89,14 +89,14 @@ RSpec.describe "Bookmarks", type: :system do
 
       it "削除リンクが表示されること" do
         visit bookmark_path(bookmark)
-        expect(page).to have_content "削除"
+        expect(page).to have_selector "i[aria-label='ブックマークの削除']"
       end
 
       it "ブックマークを削除できること", js: true do
         expect do
           visit bookmark_path(bookmark)
           page.accept_confirm do
-            click_on "削除"
+            find("i[aria-label='ブックマークの削除']").click
           end
           find ".notice", text: "ブックマークを削除しました"
         end.to change { user.bookmarks.count }.by(-1)

--- a/spec/system/categories_spec.rb
+++ b/spec/system/categories_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe "Categories", type: :system do
       it "カテゴリー名を編集できること" do
         category = create(:category, name: "元のカテゴリー名", user: user)
         visit category_path(category)
-        click_on "編集"
+        find(".category__edit-link").click
         fill_in "カテゴリー名", with: "新しいカテゴリー名"
         click_on "編集"
         expect(page).to have_selector "h1", text: "新しいカテゴリー名"
@@ -49,9 +49,8 @@ RSpec.describe "Categories", type: :system do
       it "カテゴリーを削除できること", js: true do
         expect do
           visit category_path(category)
-          click_on "編集"
           page.accept_confirm do
-            click_on "削除"
+            find("i[aria-label='カテゴリーの削除']").click
           end
           find ".notice", text: "カテゴリーを削除しました"
         end.to change { user.categories.count }.by(-1)

--- a/spec/system/timestamps_spec.rb
+++ b/spec/system/timestamps_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe "Timestamps", type: :system do
         timestamp = create(:timestamp, hour: 1, minute: 1, second: 1, start_time: 3661, bookmark: bookmark)
         visit bookmark_path(bookmark)
         within ".timestamps-table-0" do
-          click_on "編集"
+          find(".timestamp__edit-link").click
         end
         within ".timestamps-edit" do
           fill_in "時間", with: 2
@@ -67,7 +67,7 @@ RSpec.describe "Timestamps", type: :system do
           visit bookmark_path(bookmark)
           within ".timestamps-table-0" do
             page.accept_confirm do
-              click_on "削除"
+              find("i[aria-label='タイムスタンプの削除']").click
             end
           end
           find ".notice", text: "タイムスタンプを削除しました"

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -70,7 +70,9 @@ RSpec.describe "Users", type: :system do
 
       it "ログアウトできること" do
         visit root_path
-        click_on "ログアウト"
+        within ".header__dropdown--pc" do
+          click_on "ログアウト"
+        end
         expect(page).to have_selector ".notice", text: "ログアウトしました。"
       end
     end
@@ -101,12 +103,16 @@ RSpec.describe "Users", type: :system do
 
     context "ゲストユーザー自身に関する処理" do
       it "プロフィールを表示できること" do
-        click_on "プロフィール"
+        within ".header__dropdown--pc" do
+          click_on "プロフィール"
+        end
         expect(page).to have_content "ゲスト"
       end
 
       it "プロフィールは編集できないこと" do
-        click_on "プロフィール"
+        within ".header__dropdown--pc" do
+          click_on "プロフィール"
+        end
         click_on "プロフィール編集"
         fill_in "名前", with: "新しい名前"
         fill_in "プロフィール", with: "新しいプロフィール"
@@ -115,9 +121,9 @@ RSpec.describe "Users", type: :system do
       end
 
       it "退会できないこと", js: true do
-        click_on "メニュー"
-        expect(page).to have_content "プロフィール"
-        click_on "プロフィール"
+        within ".header__dropdown--pc" do
+          click_on "プロフィール"
+        end
         click_on "ユーザー情報変更"
         click_on "退会する"
         visit users_confirm_path
@@ -129,7 +135,9 @@ RSpec.describe "Users", type: :system do
 
       it "ログアウトできること" do
         visit root_path
-        click_on "ログアウト"
+        within ".header__dropdown--pc" do
+          click_on "ログアウト"
+        end
         expect(page).to have_selector ".notice", text: "ログアウトしました。"
       end
     end


### PR DESCRIPTION
# 実装内容
- Bootstrap Icons導入
- PC表示の場合はドロップダウンメニューではなくヘッダーにすべてのリンクが表示されるよう変更
- ファーストビューを作成
- アプリの使い方動画・タイムスタンプを作成
- ログイン後のリダイレクト先をbookmark/indexに変更
- アカウント情報変更後のリダイレクト先をbsers/showに変更
- フラッシュメッセージの文言変更
- ボタン・余白等の調整
- ビューの変更に伴うテストの修正