### PR TITLE
バリデーション・エラーメッセージ等

### DIFF
--- a/app/controllers/timestamps_controller.rb
+++ b/app/controllers/timestamps_controller.rb
@@ -6,8 +6,8 @@ class TimestampsController < ApplicationController
   def create
     @timestamp = Timestamp.new(timestamp_params)
     @bookmark = @timestamp.bookmark
+    @timestamp.start_time = @timestamp.calculate_start_time(timestamp_params)
     if @timestamp.valid? && @bookmark.user_id == @user.id
-      @timestamp.start_time = @timestamp.calculate_start_time(timestamp_params)
       @timestamp.save
       flash[:notice] = "登録完了しました"
       redirect_to bookmark_path(@timestamp.bookmark)

--- a/app/models/timestamp.rb
+++ b/app/models/timestamp.rb
@@ -7,6 +7,7 @@ class Timestamp < ApplicationRecord
     validates :second
   end
   validates :comment, length: { maximum: 150 }
+  validates :start_time, uniqueness: { scope: :bookmark_id, message: "指定した時間のタイムスタンプはすでに登録されています" } # rubocop:disable Rails/UniqueValidationWithoutIndex
   validate :bookmark_has_ten_or_less_timestamps_create, on: :create
   validate :bookmark_has_ten_or_less_timestamps_update, on: :update
 

--- a/app/views/bookmarks/show.html.erb
+++ b/app/views/bookmarks/show.html.erb
@@ -3,9 +3,6 @@
 <div id="bookmark-show" class="container mb-4">
   <div id="bookmark-show__row" class="row justify-content-center align-items-center">
     <div id="bookmark-show__column" class="col-lg-8 col-md-10 mb-4">
-
-      <%= render 'shared/error_messages', obj: @timestamp %>
-
       <div id="bookmark-video" class="ratio ratio-16x9">
         <iframe src="https://www.youtube.com/embed/<%= @bookmark.video_id %>" class="youtube-video-player" title="YouTube video player" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
       </div>

--- a/app/views/bookmarks/show.html.erb
+++ b/app/views/bookmarks/show.html.erb
@@ -37,7 +37,7 @@
           <%= link_to edit_bookmark_path(@bookmark) do %>
             <i class="bi bi-pencil-fill mx-1" aria-label="ブックマークの編集"></i>
           <% end %>
-          <%= link_to bookmark_path(@bookmark), data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" } do %>
+          <%= link_to bookmark_path(@bookmark), data: { turbo_method: :delete, turbo_confirm: "ブックマークを削除しますか？" } do %>
             <i class="bi bi-trash3-fill mx-1" aria-label="ブックマークの削除"></i>
           <% end %>
         </div>

--- a/app/views/shared/_timestamps_list.html.erb
+++ b/app/views/shared/_timestamps_list.html.erb
@@ -19,7 +19,7 @@
           <td class="timestamps__td4">
             <%= link_to timestamp_path(timestamp),
                         class: "timestamp__delete-link",
-                        data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" } do %>
+                        data: { turbo_method: :delete, turbo_confirm: "タイムスタンプを削除しますか？" } do %>
               <i class="bi bi-trash3-fill mx-1" aria-label="タイムスタンプの削除"></i>
             <% end %>
           </td>

--- a/app/views/shared/_timestamps_new.html.erb
+++ b/app/views/shared/_timestamps_new.html.erb
@@ -1,3 +1,4 @@
+<%= render 'shared/error_messages', obj: timestamp %>
 <div class="timestamps-new row align-items-center mt-4">
   <%= form_with model: timestamp do |f| %>
     <div class="d-flex">

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -31,6 +31,12 @@ ja:
         second: 秒
         start_time: 開始時間
         comment: メモ
+    errors:
+      models:
+        timestamp:
+          attributes:
+            start_time:
+              format: "%{message}"
   views:
     pagination:
       first: <i class="bi bi-chevron-double-left"></i>

--- a/spec/factories/timestamps.rb
+++ b/spec/factories/timestamps.rb
@@ -1,8 +1,8 @@
 FactoryBot.define do
   factory :timestamp do
-    hour { 1 }
-    minute { 1 }
-    second { 1 }
-    start_time { 3661 }
+    hour { 0 }
+    sequence(:minute) { |n| n }
+    sequence(:second) { |n| n }
+    sequence(:start_time) { |n| 0 + n.to_i * 60 + n.to_i }
   end
 end

--- a/spec/models/timestamp_spec.rb
+++ b/spec/models/timestamp_spec.rb
@@ -6,13 +6,13 @@ RSpec.describe Timestamp, type: :model do
   describe "バリデーションの検証" do
     it "既存のタイムスタンプが9件以下の場合正常に登録できること" do
       create_list(:timestamp, 9, bookmark: bookmark)
-      timestamp = build(:timestamp, bookmark_id: bookmark.id)
+      timestamp = build(:timestamp, hour: 1, minute: 1, second: 1, bookmark_id: bookmark.id)
       expect(timestamp).to be_valid
     end
 
     it "既存のタイムスタンプが10件存在する場合は登録できないこと" do
       create_list(:timestamp, 10, bookmark: bookmark)
-      timestamp = build(:timestamp, bookmark_id: bookmark.id)
+      timestamp = build(:timestamp, hour: 1, minute: 1, second: 1, bookmark_id: bookmark.id)
       expect(timestamp).to be_invalid
     end
   end

--- a/spec/models/timestamp_spec.rb
+++ b/spec/models/timestamp_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Timestamp, type: :model do
       timestamp = build(:timestamp, bookmark_id: bookmark.id)
       expect(timestamp).to be_valid
     end
+
     it "既存のタイムスタンプが10件存在する場合は登録できないこと" do
       create_list(:timestamp, 10, bookmark: bookmark)
       timestamp = build(:timestamp, bookmark_id: bookmark.id)

--- a/spec/requests/timestamps_spec.rb
+++ b/spec/requests/timestamps_spec.rb
@@ -24,43 +24,25 @@ RSpec.describe "Timestamps", type: :request do
     end
 
     it "他のユーザーのタイムスタンプは編集できないこと" do
-      params = {
-        url: bookmark.url,
-        description: bookmark.description,
-        timestamps_attributes: {
-          "0": {
-            id: timestamp.id,
-            bookmark_id: bookmark.id,
-            hour: 0,
-            minute: 0,
-            second: 0,
-            comment: "コメント",
-            _destroy: 0,
-          },
-        },
+      timestamp_params = {
+        bookmark_id: bookmark.id,
+        hour: 9,
+        minute: 9,
+        second: 9,
+        comment: "メモ",
       }
-      patch bookmark_path(bookmark), params: { bookmark: params }
-      expect(timestamp.reload.hour).to_not eq 0
+      patch bookmark_path(bookmark), params: { bookmark: timestamp_params }
+      aggregate_failures do
+        expect(timestamp.reload.hour).to_not eq 9
+        expect(timestamp.reload.second).to_not eq 9
+        expect(timestamp.reload.minute).to_not eq 9
+        expect(timestamp.reload.comment).to_not eq "メモ"
+      end
     end
 
     it "他のユーザーのタイムスタンプは削除できないこと" do
-      params = {
-        url: bookmark.url,
-        description: bookmark.description,
-        timestamps_attributes: {
-          "0": {
-            id: timestamp.id,
-            bookmark_id: bookmark.id,
-            hour: 0,
-            minute: 0,
-            second: 0,
-            comment: "コメント",
-            _destroy: 1,
-          },
-        },
-      }
       expect do
-        patch bookmark_path(bookmark), params: { bookmark: params }
+        delete bookmark_path(bookmark)
       end.to change { bookmark.timestamps.count }.by(0)
     end
   end
@@ -83,43 +65,25 @@ RSpec.describe "Timestamps", type: :request do
     end
 
     it "他のユーザーのタイムスタンプは編集できないこと" do
-      params = {
-        url: bookmark.url,
-        description: bookmark.description,
-        timestamps_attributes: {
-          "0": {
-            id: timestamp.id,
-            bookmark_id: bookmark.id,
-            hour: 0,
-            minute: 0,
-            second: 0,
-            comment: "コメント",
-            _destroy: 0,
-          },
-        },
+      timestamp_params = {
+        bookmark_id: bookmark.id,
+        hour: 9,
+        minute: 9,
+        second: 9,
+        comment: "メモ",
       }
-      patch bookmark_path(bookmark), params: { bookmark: params }
-      expect(timestamp.reload.hour).to_not eq 0
+      patch bookmark_path(bookmark), params: { bookmark: timestamp_params }
+      aggregate_failures do
+        expect(timestamp.reload.hour).to_not eq 9
+        expect(timestamp.reload.second).to_not eq 9
+        expect(timestamp.reload.minute).to_not eq 9
+        expect(timestamp.reload.comment).to_not eq "メモ"
+      end
     end
 
     it "他のユーザーのタイムスタンプは削除できないこと" do
-      params = {
-        url: bookmark.url,
-        description: bookmark.description,
-        timestamps_attributes: {
-          "0": {
-            id: timestamp.id,
-            bookmark_id: bookmark.id,
-            hour: 0,
-            minute: 0,
-            second: 0,
-            comment: "コメント",
-            _destroy: 1,
-          },
-        },
-      }
       expect do
-        patch bookmark_path(bookmark), params: { bookmark: params }
+        delete bookmark_path(bookmark)
       end.to change { bookmark.timestamps.count }.by(0)
     end
   end


### PR DESCRIPTION
# 実装内容
- タイムスタンプのエラーメッセージの位置をフォームの近くに変更
- ブックマークの削除かタイムスタンプの削除かをわかりやすくするためモーダル内の文言を変更
- 1つのブックマーク内で同じ開始時間のタイムスタンプを作成できないようバリデーション設定
- テストの修正