### PR TITLE
パスワードの表示・非表示（修正）

### DIFF
--- a/app/javascript/custom/password_show.js
+++ b/app/javascript/custom/password_show.js
@@ -52,7 +52,7 @@ function showUserCurrentPassword() {
   };
 };
 
-document.addEventListener('turbo:load', function() {
+document.addEventListener('DOMContentLoaded', function() {
   showUserPassword();
   showUserPasswordConfirmation();
   showUserCurrentPassword();


### PR DESCRIPTION
## 実装内容
- 'turbo:render'と'turbo:load'が競合して無効になっていたため修正