### PR TITLE
退会したユーザーの再登録・ログイン

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -9,14 +9,12 @@ class Users::SessionsController < Devise::SessionsController
   end
 
   def reject_deleted_user
-    @user = User.find_by(email: params[:user][:email])
-    if @user
-      if @user.valid_password?(params[:user][:password]) && (@user.is_deleted == true)
-        flash[:notice] = "退会済みです。再度登録をしてご利用ください。"
-        redirect_to new_user_registration_path
-      end
-    else
-      flash[:notice] = "ユーザーが見つかりません"
+    user = User.where(email: params[:user][:email])
+    user_status = user.pluck(:is_deleted)
+    if user.blank?
+      return
+    elsif user_status.all? { |is_deleted| is_deleted == true }
+      flash[:alert] = "退会済みです。再度登録をしてご利用ください。"
       redirect_to new_user_registration_path
     end
   end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -11,9 +11,7 @@ class Users::SessionsController < Devise::SessionsController
   def reject_deleted_user
     user = User.where(email: params[:user][:email])
     user_status = user.pluck(:is_deleted)
-    if user.blank?
-      return
-    elsif user_status.all? { |is_deleted| is_deleted == true }
+    if user.present? && user_status.all? { |is_deleted| is_deleted == true }
       flash[:alert] = "退会済みです。再度登録をしてご利用ください。"
       redirect_to new_user_registration_path
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -35,6 +35,12 @@ class User < ApplicationRecord
     super && (is_deleted == false)
   end
 
+  def self.find_for_authentication(tainted_conditions)
+    conditions = devise_parameter_filter.filter(tainted_conditions)
+    conditions[:is_deleted] = false
+    to_adapter.find_first(conditions)
+  end
+
   def self.from_omniauth(auth)
     find_or_create_by(provider: auth.provider, uid: auth.uid) do |user|
       user.email = auth.info.email


### PR DESCRIPTION
## 目標
- 退会したユーザーが再登録したアカウントでログインできないバグの解消

## 実装内容
- is_deletedがfalseのデータを認証に使用するため`find_for_authentication`メソッドをオーバーライド
- 再登録時に前のアカウントと同じパスワードで登録するとログインできなくなってしまうため`reject_deleted_user`メソッドを修正